### PR TITLE
feat(server): support vertex id up to 1MB (#3087)

### DIFF
--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/OffheapCache.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/cache/OffheapCache.java
@@ -177,7 +177,7 @@ public class OffheapCache extends AbstractCache<Id, Object> {
         @Override
         public int serializedSize(Id id) {
             // NOTE: return size must be == actual bytes to write
-            return BytesBuffer.allocate(id.length() + 2).writeId(id).position();
+            return BytesBuffer.allocate(id.length() + 4).writeId(id).position();
         }
     }
 

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/id/IdUtil.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/id/IdUtil.java
@@ -58,7 +58,7 @@ public final class IdUtil {
     }
 
     public static Object writeBinString(Id id) {
-        int len = id.edge() ? BytesBuffer.BUF_EDGE_ID : id.length() + 1;
+        int len = id.edge() ? BytesBuffer.BUF_EDGE_ID : id.length() + 4;
         BytesBuffer buffer = BytesBuffer.allocate(len).writeId(id);
         buffer.forReadWritten();
         return buffer.asByteBuffer();

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinarySerializer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BinarySerializer.java
@@ -105,7 +105,8 @@ public class BinarySerializer extends AbstractSerializer {
     @Override
     protected BinaryBackendEntry newBackendEntry(HugeType type, Id id) {
         if (type.isVertex()) {
-            BytesBuffer buffer = BytesBuffer.allocate(2 + 1 + id.length());
+            // +4 for string id length prefix (up to 3 bytes) + type/partition
+            BytesBuffer buffer = BytesBuffer.allocate(2 + 4 + id.length());
             writePartitionedId(HugeType.VERTEX, id, buffer);
             return new BinaryBackendEntry(type, new BinaryId(buffer.bytes(), id));
         }
@@ -130,7 +131,7 @@ public class BinarySerializer extends AbstractSerializer {
             return new BinaryBackendEntry(type, new BinaryId(idBytes, id));
         }
 
-        BytesBuffer buffer = BytesBuffer.allocate(1 + id.length());
+        BytesBuffer buffer = BytesBuffer.allocate(4 + id.length());
         byte[] idBytes = buffer.writeId(id).bytes();
         return new BinaryBackendEntry(type, new BinaryId(idBytes, id));
     }
@@ -644,11 +645,11 @@ public class BinarySerializer extends AbstractSerializer {
         if (type.isEdge()) {
             id = writeEdgeId(id);
         } else if (type.isVertex()) {
-            BytesBuffer buffer = BytesBuffer.allocate(2 + 1 + id.length());
+            BytesBuffer buffer = BytesBuffer.allocate(2 + 4 + id.length());
             writePartitionedId(HugeType.VERTEX, id, buffer);
             id = new BinaryId(buffer.bytes(), id);
         } else {
-            BytesBuffer buffer = BytesBuffer.allocate(1 + id.length());
+            BytesBuffer buffer = BytesBuffer.allocate(4 + id.length());
             id = new BinaryId(buffer.writeId(id).bytes(), id);
         }
         return id;

--- a/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
+++ b/hugegraph-server/hugegraph-core/src/main/java/org/apache/hugegraph/backend/serializer/BytesBuffer.java
@@ -60,8 +60,11 @@ public final class BytesBuffer extends OutputStream {
 
     // TODO: support user-defined configuration
     // NOTE: +1 to let code 0 represent length 1
-    public static final int ID_LEN_MAX = 0x3fff + 1; // 16KB
-    public static final int EID_LEN_MAX = 64 * 1024;
+    // 2-byte length prefix covers up to 16KB; 3-byte prefix covers up to 1MB
+    public static final int ID_LEN_2BYTES_MAX = 0x3fff + 1; // 16KB
+    public static final int ID_LEN_MAX = (int) Bytes.MB; // 1MB
+    // Edge id may contain two vertex ids + labels + sort values
+    public static final int EID_LEN_MAX = 3 * (int) Bytes.MB;
 
     public static final byte STRING_ENDING_BYTE = (byte) 0x00;
     public static final byte STRING_ENDING_BYTE_FF = (byte) 0xff;
@@ -729,16 +732,22 @@ public final class BytesBuffer extends OutputStream {
                     E.checkArgument(false, "Big id max length is %s, but got %s {%s}",
                                     ID_LEN_MAX, len, id);
                 }
-                len -= 1; // mapping [1, 16384] to [0, 16383]
+                len -= 1; // mapping [1, ID_LEN_MAX] to [0, ID_LEN_MAX - 1]
                 if (len <= 0x3f) {
                     // If length is <= 63, use a single byte with the highest bit set to 1
                     this.writeUInt8(len | 0x80);
-                } else {
+                } else if (len < ID_LEN_2BYTES_MAX) {
                     int high = len >> 8;
                     int low = len & 0xff;
                     // Write high 8 bits with highest two bits set to 11
                     this.writeUInt8(high | 0xc0);
                     this.writeUInt8(low);
+                } else {
+                    // 0x7d marks a huge string id with 3-byte length prefix
+                    this.writeUInt8(0x7d);
+                    this.writeUInt8((len >>> 16) & 0xff);
+                    this.writeUInt8((len >>> 8) & 0xff);
+                    this.writeUInt8(len & 0xff);
                 }
                 this.write(bytes);
                 break;
@@ -756,6 +765,14 @@ public final class BytesBuffer extends OutputStream {
             } else if (b == 0x7e) {
                 // Edge Id
                 return this.readEdgeId();
+            } else if (b == 0x7d) {
+                // Huge string Id with 3-byte length prefix
+                int len = (this.readUInt8() << 16) |
+                          (this.readUInt8() << 8) |
+                          this.readUInt8();
+                len += 1; // restore [0, ID_LEN_MAX - 1] to [1, ID_LEN_MAX]
+                byte[] id = this.read(len);
+                return IdGenerator.of(id, IdType.STRING);
             } else {
                 // Number Id
                 return IdGenerator.of(this.readNumber(b));
@@ -910,6 +927,7 @@ public final class BytesBuffer extends OutputStream {
          *
          * NOTE:    0b 0111 1111 is used by 128 bits UUID
          *          0b 0111 1110 is used by EdgeId
+         *          0b 0111 1101 is used by huge string Id (>=16KB)
          */
         int positive = val >= 0 ? 0x08 : 0x00;
         if (~0x7ffL <= val && val <= 0x7ffL) {

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/core/VertexCoreTest.java
@@ -1099,12 +1099,23 @@ public class VertexCoreTest extends BaseCoreTest {
                             "name", "marko", "age", 18, "city", "Beijing");
         });
 
-        // Expect id length <= BytesBuffer.ID_LEN_MAX
+        // Expect id length <= BytesBuffer.ID_LEN_MAX (1MB)
+        String maxId = new String(new char[BytesBuffer.ID_LEN_MAX]).replace('\0', 'a');
+        assert maxId.length() == BytesBuffer.ID_LEN_MAX;
+        graph.addVertex(T.label, "programmer", T.id, maxId,
+                        "name", "marko", "age", 18, "city", "Beijing");
+        this.mayCommitTx();
+        Assert.assertTrue(graph.traversal().V(maxId).hasNext());
+
         Assert.assertThrows(IllegalArgumentException.class, () -> {
-            String largeId = new String(new byte[BytesBuffer.ID_LEN_MAX]) + ".";
+            String largeId = maxId + ".";
             assert largeId.length() == BytesBuffer.ID_LEN_MAX + 1;
             graph.addVertex(T.label, "programmer", T.id, largeId,
                             "name", "marko", "age", 18, "city", "Beijing");
+        }, e -> {
+            Assert.assertContains(String.format("The max length of vertex id is %s",
+                                                BytesBuffer.ID_LEN_MAX),
+                                  e.getMessage());
         });
     }
 

--- a/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
+++ b/hugegraph-server/hugegraph-test/src/main/java/org/apache/hugegraph/unit/serializer/BytesBufferTest.java
@@ -379,22 +379,14 @@ public class BytesBufferTest extends BaseUnitTest {
                                                    .writeId(id).bytes());
         Assert.assertEquals(id, BytesBuffer.wrap(bytes).readId());
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BytesBuffer.allocate(0).writeId(IdGenerator.of(genString(BytesBuffer.ID_LEN_MAX + 1)));
-        }, e -> {
-            Assert.assertContains(String.format("Big id max length is %s, but got %s",
-                                                BytesBuffer.ID_LEN_MAX,
-                                                BytesBuffer.ID_LEN_MAX + 1),
-                                  e.getMessage());
-        });
-        Assert.assertThrows(IllegalArgumentException.class, () -> {
-            BytesBuffer.allocate(0).writeId(IdGenerator.of(genString(BytesBuffer.ID_LEN_MAX + 2)));
-        }, e -> {
-            Assert.assertContains(String.format("Big id max length is %s, but got %s",
-                                                BytesBuffer.ID_LEN_MAX,
-                                                BytesBuffer.ID_LEN_MAX + 2),
-                                  e.getMessage());
-        });
+        // Max length with 2-byte prefix (16KB)
+        id = IdGenerator.of(genString(BytesBuffer.ID_LEN_2BYTES_MAX));
+        bytes = genBytes(BytesBuffer.ID_LEN_2BYTES_MAX + 2);
+        bytes[0] = (byte) 0xff;
+        bytes[1] = (byte) 0xff;
+        Assert.assertArrayEquals(bytes, BytesBuffer.allocate(0)
+                                                   .writeId(id).bytes());
+        Assert.assertEquals(id, BytesBuffer.wrap(bytes).readId());
     }
 
     @Test
@@ -407,18 +399,27 @@ public class BytesBufferTest extends BaseUnitTest {
                                                    .writeId(id).bytes());
         Assert.assertEquals(id, BytesBuffer.wrap(bytes).readId());
 
-        id = IdGenerator.of(genString(BytesBuffer.ID_LEN_MAX - 1));
-        bytes = genBytes(BytesBuffer.ID_LEN_MAX + 1);
-        bytes[0] = (byte) 0xff;
-        bytes[1] = (byte) 0xfe;
+        // First length that needs 3-byte prefix (>16KB)
+        int hugeLen = BytesBuffer.ID_LEN_2BYTES_MAX + 1;
+        id = IdGenerator.of(genString(hugeLen));
+        bytes = genBytes(hugeLen + 4);
+        int encodedLen = hugeLen - 1;
+        bytes[0] = (byte) 0x7d;
+        bytes[1] = (byte) ((encodedLen >>> 16) & 0xff);
+        bytes[2] = (byte) ((encodedLen >>> 8) & 0xff);
+        bytes[3] = (byte) (encodedLen & 0xff);
         Assert.assertArrayEquals(bytes, BytesBuffer.allocate(0)
                                                    .writeId(id).bytes());
         Assert.assertEquals(id, BytesBuffer.wrap(bytes).readId());
 
+        // Max length 1MB
         id = IdGenerator.of(genString(BytesBuffer.ID_LEN_MAX));
-        bytes = genBytes(BytesBuffer.ID_LEN_MAX + 2);
-        bytes[0] = (byte) 0xff;
-        bytes[1] = (byte) 0xff;
+        bytes = genBytes(BytesBuffer.ID_LEN_MAX + 4);
+        encodedLen = BytesBuffer.ID_LEN_MAX - 1;
+        bytes[0] = (byte) 0x7d;
+        bytes[1] = (byte) ((encodedLen >>> 16) & 0xff);
+        bytes[2] = (byte) ((encodedLen >>> 8) & 0xff);
+        bytes[3] = (byte) (encodedLen & 0xff);
         Assert.assertArrayEquals(bytes, BytesBuffer.allocate(0)
                                                    .writeId(id).bytes());
         Assert.assertEquals(id, BytesBuffer.wrap(bytes).readId());

--- a/hugegraph-struct/src/main/java/org/apache/hugegraph/serializer/BytesBuffer.java
+++ b/hugegraph-struct/src/main/java/org/apache/hugegraph/serializer/BytesBuffer.java
@@ -63,8 +63,11 @@ public class BytesBuffer extends OutputStream {
     public static final long WRITE_BYTES_MAX_LENGTH = 10 * Bytes.MB;
 
     // NOTE: +1 to let code 0 represent length 1
-    public static final int ID_LEN_MAX = 0x7fff + 1;
-    public static final int BIG_ID_LEN_MAX = 0xfffff + 1;
+    // 2-byte length prefix covers up to 16KB; 3-byte prefix covers up to 1MB
+    public static final int ID_LEN_2BYTES_MAX = 0x3fff + 1; // 16KB
+    public static final int ID_LEN_MAX = (int) Bytes.MB; // 1MB
+    // Edge id may contain two vertex ids + labels + sort values
+    public static final int BIG_ID_LEN_MAX = 3 * (int) Bytes.MB;
 
     public static final byte STRING_ENDING_BYTE = (byte) 0x00;
     public static final byte STRING_ENDING_BYTE_FF = (byte) 0xff;
@@ -703,17 +706,23 @@ public class BytesBuffer extends OutputStream {
                 bytes = id.asBytes();
                 int len = bytes.length;
                 E.checkArgument(len > 0, "Can't write empty id");
-                E.checkArgument(len <= 16384,
+                E.checkArgument(len <= ID_LEN_MAX,
                                 "Big id max length is %s, but got %s {%s}",
-                                16384, len, id);
-                len -= 1;
-                if (len <= 63) {
+                                ID_LEN_MAX, len, id);
+                len -= 1; // mapping [1, ID_LEN_MAX] to [0, ID_LEN_MAX - 1]
+                if (len <= 0x3f) {
                     this.writeUInt8(len | 0x80);
-                } else {
+                } else if (len < ID_LEN_2BYTES_MAX) {
                     int high = len >> 8;
                     int low = len & 0xff;
                     this.writeUInt8(high | 0xc0);
                     this.writeUInt8(low);
+                } else {
+                    // 0x7d marks a huge string id with 3-byte length prefix
+                    this.writeUInt8(0x7d);
+                    this.writeUInt8((len >>> 16) & 0xff);
+                    this.writeUInt8((len >>> 8) & 0xff);
+                    this.writeUInt8(len & 0xff);
                 }
 
                 this.write(bytes);
@@ -736,6 +745,14 @@ public class BytesBuffer extends OutputStream {
             } else if (b == 0x7e) {
                 // Edge Id
                 return this.readEdgeId();
+            } else if (b == 0x7d) {
+                // Huge string Id with 3-byte length prefix
+                int len = (this.readUInt8() << 16) |
+                          (this.readUInt8() << 8) |
+                          this.readUInt8();
+                len += 1; // restore [0, ID_LEN_MAX - 1] to [1, ID_LEN_MAX]
+                byte[] id = this.read(len);
+                return IdGenerator.of(id, IdType.STRING);
             } else {
                 // Number Id
                 return IdGenerator.of(this.readNumber(b));
@@ -896,6 +913,7 @@ public class BytesBuffer extends OutputStream {
          *
          * NOTE:    0b 0111 1111 is used by 128 bits UUID
          *          0b 0111 1110 is used by EdgeId
+         *          0b 0111 1101 is used by huge string Id (>=16KB)
          */
         int positive = val >= 0 ? 0x08 : 0x00;
         if (~0x7ffL <= val && val <= 0x7ffL) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Purpose of the PR

- fix #3087

Support customized string vertex IDs up to **1MB**. Previously the hard limit was 128 bytes (later raised to 16KB in #2622); inserting a longer id via REST API failed with `The max length of vertex id is ...`.

## Main Changes

- Extend `BytesBuffer` string-id encoding with a 3-byte length prefix marked by `0x7d` for IDs larger than 16KB
- Keep existing 1-byte / 2-byte encodings for IDs ≤ 16KB (backward compatible for stored data)
- Raise `ID_LEN_MAX` to `1MB` and `EID_LEN_MAX` to `3MB` (edge id may contain two large vertex ids)
- Align the same encoding/limit changes in `hugegraph-struct`
- Update related buffer allocations (`BinarySerializer`, `OffheapCache`, `IdUtil`) and unit/core tests

### Encoding format (string id)

| Length | Prefix |
|--------|--------|
| 1–64 | 1 byte (`0x80 \| len-1`) |
| 65–16384 | 2 bytes (`0xc0 \| high`, `low`) |
| 16385–1048576 | `0x7d` + 3-byte length |

## Verifying these changes

- [x] Already covered by existing tests, such as `BytesBufferTest` / `VertexCoreTest` (updated for 1MB)
- [x] Need tests and can be verified as follows:
    - `mvn test -pl hugegraph-server/hugegraph-test -am -P unit-test -Dtest=BytesBufferTest`
    - `mvn test -pl hugegraph-server/hugegraph-test -am -P unit-test -Dtest=IdUtilTest`
    - Insert a customized string vertex id of length 130 / up to 1MB via REST API

## Does this PR potentially affect the following parts?

- [ ]  Dependencies (add/update license info & regenerate_known_dependencies.sh)
- [ ]  Modify configurations
- [x]  The public API
- [x]  Other affects (binary id encoding extended; old data remains readable)
- [ ]  Nope

## Documentation Status

- [x]  `Doc - TODO`
- [ ]  `Doc - Done`
- [ ]  `Doc - No Need`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a8798b6-b20b-4e7d-a732-06bbf473ff05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a8798b6-b20b-4e7d-a732-06bbf473ff05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

